### PR TITLE
update schema utils to allow nullable repeated fields

### DIFF
--- a/core/src/main/java/org/streamprocessor/core/utils/SchemaUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/SchemaUtils.java
@@ -80,6 +80,7 @@ class SchemaUtils {
             field = field.withNullable(false);
         } else if ("REPEATED".equals(column.getMode())) {
             field = Field.of(name, FieldType.array(fieldType));
+            field = field.withNullable(true);
         } else {
             throw new UnsupportedOperationException(
                     "Field mode '"


### PR DESCRIPTION
This PR sets the nullable property on all repeated fields. I guess that is what we want? In bigquery the mode is either nullable, required or repeated so we will have to decide if a repeated is nullable or no?