### PR TITLE
Set schemamissing log to warning severity

### DIFF
--- a/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
@@ -132,8 +132,27 @@ public class SerializeMessageToRowFn extends DoFn<PubsubMessage, Row> {
 
             Row row = BqUtils.toBeamRow(schema, tr);
             out.get(successTag).output(row);
+        } catch (NoSchemaException e) {
+            LOG.warn("exception[{}] step[{}] details[{}] entity[{}]",
+                "NoSchemaException",
+                "SerializeMessageToRowFn.processElement()",    
+                e.toString(),
+                entity
+            );
         } catch (Exception e) {
-            LOG.error(entity + ": " + e.toString());
+            LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
+                e.getClass().getName(),
+                "SerializeMessageToRowFn.processElement()",
+                e.toString(),
+                entity
+                // TODO: Add labels to error for consumption by log monitoring tool
+                // Map.of(
+                //     "entity", entity,
+                //     "dataset", datasetId,
+                //     "error_code", e.getClass().getName(),
+                //     "error_step", "SerializeMessageToRowFn.processElement()"
+                // )
+            );
             // TODO:
             // instead, pass the following to deadletter: original_payload, status, error_message
             // can't put in unmodifiable map

--- a/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
@@ -133,26 +133,27 @@ public class SerializeMessageToRowFn extends DoFn<PubsubMessage, Row> {
             Row row = BqUtils.toBeamRow(schema, tr);
             out.get(successTag).output(row);
         } catch (NoSchemaException e) {
-            LOG.warn("exception[{}] step[{}] details[{}] entity[{}]",
-                "NoSchemaException",
-                "SerializeMessageToRowFn.processElement()",    
-                e.toString(),
-                entity
-            );
+            LOG.warn(
+                    "exception[{}] step[{}] details[{}] entity[{}]",
+                    "NoSchemaException",
+                    "SerializeMessageToRowFn.processElement()",
+                    e.toString(),
+                    entity);
         } catch (Exception e) {
-            LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
-                e.getClass().getName(),
-                "SerializeMessageToRowFn.processElement()",
-                e.toString(),
-                entity
-                // TODO: Add labels to error for consumption by log monitoring tool
-                // Map.of(
-                //     "entity", entity,
-                //     "dataset", datasetId,
-                //     "error_code", e.getClass().getName(),
-                //     "error_step", "SerializeMessageToRowFn.processElement()"
-                // )
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}] entity[{}]",
+                    e.getClass().getName(),
+                    "SerializeMessageToRowFn.processElement()",
+                    e.toString(),
+                    entity
+                    // TODO: Add labels to error for consumption by log monitoring tool
+                    // Map.of(
+                    //     "entity", entity,
+                    //     "dataset", datasetId,
+                    //     "error_code", e.getClass().getName(),
+                    //     "error_step", "SerializeMessageToRowFn.processElement()"
+                    // )
+                    );
             // TODO:
             // instead, pass the following to deadletter: original_payload, status, error_message
             // can't put in unmodifiable map

--- a/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
@@ -102,14 +102,14 @@ public final class CacheLoaderUtils implements Serializable {
             return schema;
         } catch (PermissionDeniedException e) {
             LOG.warn("exception[{}] step[{}] details[{}]",
-                "NoSchemaException",
-                "CacheLoaderUtils.getSchema()",    
+                "PermissionDeniedException",
+                "CacheLoaderUtils.getSchema()",
                 e.toString()
             );
             return Schema.builder().build();
         } catch (Exception e) {
             LOG.error("exception[{}] step[{}] details[{}]",
-                "NoSchemaException",
+                e.getClass().getName(),
                 "CacheLoaderUtils.getSchema()",
                 e.toString()
             );

--- a/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
@@ -101,18 +101,18 @@ public final class CacheLoaderUtils implements Serializable {
                     Schema.builder().addFields(taggedFieldList).build().withOptions(schemaOptions);
             return schema;
         } catch (PermissionDeniedException e) {
-            LOG.warn("exception[{}] step[{}] details[{}]",
-                "PermissionDeniedException",
-                "CacheLoaderUtils.getSchema()",
-                e.toString()
-            );
+            LOG.warn(
+                    "exception[{}] step[{}] details[{}]",
+                    "PermissionDeniedException",
+                    "CacheLoaderUtils.getSchema()",
+                    e.toString());
             return Schema.builder().build();
         } catch (Exception e) {
-            LOG.error("exception[{}] step[{}] details[{}]",
-                e.getClass().getName(),
-                "CacheLoaderUtils.getSchema()",
-                e.toString()
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}]",
+                    e.getClass().getName(),
+                    "CacheLoaderUtils.getSchema()",
+                    e.toString());
             return Schema.builder().build();
         }
     }

--- a/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
@@ -16,6 +16,7 @@
 
 package org.streamprocessor.core.utils;
 
+import com.google.api.gax.rpc.PermissionDeniedException;
 import com.google.cloud.datacatalog.v1beta1.DataCatalogClient;
 import com.google.cloud.datacatalog.v1beta1.Entry;
 import com.google.cloud.datacatalog.v1beta1.LookupEntryRequest;
@@ -99,8 +100,19 @@ public final class CacheLoaderUtils implements Serializable {
             Schema schema =
                     Schema.builder().addFields(taggedFieldList).build().withOptions(schemaOptions);
             return schema;
+        } catch (PermissionDeniedException e) {
+            LOG.warn("exception[{}] step[{}] details[{}]",
+                "NoSchemaException",
+                "CacheLoaderUtils.getSchema()",    
+                e.toString()
+            );
+            return Schema.builder().build();
         } catch (Exception e) {
-            LOG.error(e.toString());
+            LOG.error("exception[{}] step[{}] details[{}]",
+                "NoSchemaException",
+                "CacheLoaderUtils.getSchema()",
+                e.toString()
+            );
             return Schema.builder().build();
         }
     }


### PR DESCRIPTION
Closing branch on the [jira issue](https://mathem.atlassian.net/browse/DATA-2917?atlOrigin=eyJpIjoiOTBjMDg4NGVhYWFiNDFlZDk1ZDNlOTAwN2FiNGYyN2MiLCJwIjoiaiJ9) on too many alerts on an expected error. 

Will proceed in new branch with updating the format on error log messages so that it's coherent and easier to query using the logging query language. 

Some of this will tie together with the "future solution" as some errors shouldn't even happen when they are both expected and handled by a proper contract service that can manage a complex state of contracts/tables/environments/etc. 

After closing we will build new image spec (0.1.15) and deploy
