### PR TITLE
Data 2925 sharpen error logging

### DIFF
--- a/core/src/main/java/org/streamprocessor/core/coders/GenericRowCoder.java
+++ b/core/src/main/java/org/streamprocessor/core/coders/GenericRowCoder.java
@@ -70,11 +70,11 @@ public class GenericRowCoder extends CustomCoder<Row> {
         try {
             SerializableCoder.of(Row.class).encode(row, outStream);
         } catch (IOException e) {
-            LOG.error("exception[{}] step[{}] details[{}]",
-                e.getClass().getName(),
-                "GenericRowCoder.encode()",
-                e.toString()
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}]",
+                    e.getClass().getName(),
+                    "GenericRowCoder.encode()",
+                    e.toString());
             throw (e);
         }
     }
@@ -92,11 +92,11 @@ public class GenericRowCoder extends CustomCoder<Row> {
         try {
             return SerializableCoder.of(Row.class).decode(inStream);
         } catch (IOException e) {
-            LOG.error("exception[{}] step[{}] details[{}]",
-                e.getClass().getName(),
-                "GenericRowCoder.decode()",
-                e.toString()
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}]",
+                    e.getClass().getName(),
+                    "GenericRowCoder.decode()",
+                    e.toString());
             throw (e);
         }
     }

--- a/core/src/main/java/org/streamprocessor/core/coders/GenericRowCoder.java
+++ b/core/src/main/java/org/streamprocessor/core/coders/GenericRowCoder.java
@@ -70,7 +70,11 @@ public class GenericRowCoder extends CustomCoder<Row> {
         try {
             SerializableCoder.of(Row.class).encode(row, outStream);
         } catch (IOException e) {
-            LOG.error("GenericRowCoder encode: ", e);
+            LOG.error("exception[{}] step[{}] details[{}]",
+                e.getClass().getName(),
+                "GenericRowCoder.encode()",
+                e.toString()
+            );
             throw (e);
         }
     }
@@ -88,7 +92,11 @@ public class GenericRowCoder extends CustomCoder<Row> {
         try {
             return SerializableCoder.of(Row.class).decode(inStream);
         } catch (IOException e) {
-            LOG.error("GenericRowCoder encode: ", e);
+            LOG.error("exception[{}] step[{}] details[{}]",
+                e.getClass().getName(),
+                "GenericRowCoder.decode()",
+                e.toString()
+            );
             throw (e);
         }
     }

--- a/core/src/main/java/org/streamprocessor/core/transforms/DeIdentifyFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/DeIdentifyFn.java
@@ -161,12 +161,13 @@ public class DeIdentifyFn extends DoFn<Row, Row> {
                 return futureTransaction.get();
             }
         } catch (Exception e) {
-            LOG.error("exception[{}] step[{}] details[{}] guess[race condition?]",
-                e.getClass().getName(),
-                "DeIdentifyFn.getFieldToken()",
-                e.toString()
-            );
-            throw new RuntimeException(e.toString()); // DEBATABLE: Why through new and wrapped in a RuntimeException?
+            LOG.error(
+                    "exception[{}] step[{}] details[{}] guess[race condition?]",
+                    e.getClass().getName(),
+                    "DeIdentifyFn.getFieldToken()",
+                    e.toString());
+            throw new RuntimeException(
+                    e.toString()); // DEBATABLE: Why through new and wrapped in a RuntimeException?
         }
     }
 
@@ -302,11 +303,11 @@ public class DeIdentifyFn extends DoFn<Row, Row> {
             }
             out.output(rowBuilder.build());
         } catch (Exception e) {
-            LOG.error("exception[{}] step[{}] details[{}]",
-                e.getClass().getName(),
-                "DeIdentifyFn.processElement()",
-                e.toString()
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}]",
+                    e.getClass().getName(),
+                    "DeIdentifyFn.processElement()",
+                    e.toString());
             throw e;
         }
     }

--- a/core/src/main/java/org/streamprocessor/core/transforms/DynamodbFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/DynamodbFn.java
@@ -60,6 +60,7 @@ public class DynamodbFn extends DoFn<PubsubMessage, PubsubMessage> {
                 attributes.put("entity", received.getAttribute("topic"));
             }
 
+            String entity = attributes.get("entity");
             JSONObject payloadObject;
 
             try {
@@ -110,14 +111,28 @@ public class DynamodbFn extends DoFn<PubsubMessage, PubsubMessage> {
                 out.output(
                         new PubsubMessage(payloadObject.toString().getBytes("UTF-8"), attributes));
             } catch (IllegalArgumentException e) {
-                LOG.error("IllegalArgumentException: ", e);
+                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
+                    e.getClass().getName(),
+                    "DynamodbFn.processElement()",
+                    e.toString(),
+                    entity
+                );
             } catch (org.json.JSONException e) {
-                LOG.error("org.json.JSONException: ", e);
+                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
+                    e.getClass().getName(),
+                    "DynamodbFn.processElement()",
+                    e.toString(),
+                    entity
+                );
             } catch (Exception e) {
-                LOG.error("Exception: ", e);
+                throw e;
             }
         } catch (Exception e) {
-            LOG.error(e.getMessage());
+            LOG.error("exception[{}] step[{}] details[{}]",
+                e.getClass().getName(),
+                "DynamodbFn.processElement()",
+                e.toString()
+            );
         }
     }
 }

--- a/core/src/main/java/org/streamprocessor/core/transforms/DynamodbFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/DynamodbFn.java
@@ -111,28 +111,28 @@ public class DynamodbFn extends DoFn<PubsubMessage, PubsubMessage> {
                 out.output(
                         new PubsubMessage(payloadObject.toString().getBytes("UTF-8"), attributes));
             } catch (IllegalArgumentException e) {
-                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
-                    e.getClass().getName(),
-                    "DynamodbFn.processElement()",
-                    e.toString(),
-                    entity
-                );
+                LOG.error(
+                        "exception[{}] step[{}] details[{}] entity[{}]",
+                        e.getClass().getName(),
+                        "DynamodbFn.processElement()",
+                        e.toString(),
+                        entity);
             } catch (org.json.JSONException e) {
-                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
-                    e.getClass().getName(),
-                    "DynamodbFn.processElement()",
-                    e.toString(),
-                    entity
-                );
+                LOG.error(
+                        "exception[{}] step[{}] details[{}] entity[{}]",
+                        e.getClass().getName(),
+                        "DynamodbFn.processElement()",
+                        e.toString(),
+                        entity);
             } catch (Exception e) {
                 throw e;
             }
         } catch (Exception e) {
-            LOG.error("exception[{}] step[{}] details[{}]",
-                e.getClass().getName(),
-                "DynamodbFn.processElement()",
-                e.toString()
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}]",
+                    e.getClass().getName(),
+                    "DynamodbFn.processElement()",
+                    e.toString());
         }
     }
 }

--- a/core/src/main/java/org/streamprocessor/core/transforms/DynamodbFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/DynamodbFn.java
@@ -124,8 +124,6 @@ public class DynamodbFn extends DoFn<PubsubMessage, PubsubMessage> {
                         "DynamodbFn.processElement()",
                         e.toString(),
                         entity);
-            } catch (Exception e) {
-                throw e;
             }
         } catch (Exception e) {
             LOG.error(

--- a/core/src/main/java/org/streamprocessor/core/transforms/RowToPubsubMessageFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/RowToPubsubMessageFn.java
@@ -41,12 +41,10 @@ public class RowToPubsubMessageFn extends DoFn<Row, KV<String, PubsubMessage>> {
 
     static final long serialVersionUID = 234L;
 
-    public RowToPubsubMessageFn() {
-    }
+    public RowToPubsubMessageFn() {}
 
     @Setup
-    public void setup() throws Exception {
-    }
+    public void setup() throws Exception {}
 
     @ProcessElement
     public void processElement(@Element Row row, OutputReceiver<KV<String, PubsubMessage>> out)
@@ -75,24 +73,25 @@ public class RowToPubsubMessageFn extends DoFn<Row, KV<String, PubsubMessage>> {
                 eventUuid = UUID.randomUUID().toString();
             }
 
-            Map<String, String> attributes = new HashMap<String, String>() {
-                static final long serialVersionUID = 2342534L;
+            Map<String, String> attributes =
+                    new HashMap<String, String>() {
+                        static final long serialVersionUID = 2342534L;
 
-                {
-                    put("timestamp", java.time.Instant.now().toString());
-                    put("event_timestamp", String.valueOf(eventTimestamp.getMillis()));
-                    put("event_uuid", eventUuid);
-                    put("entity", entity);
-                }
-            };
+                        {
+                            put("timestamp", java.time.Instant.now().toString());
+                            put("event_timestamp", String.valueOf(eventTimestamp.getMillis()));
+                            put("event_uuid", eventUuid);
+                            put("entity", entity);
+                        }
+                    };
 
             out.output(KV.of(entity, new PubsubMessage(str.getBytes("UTF-8"), attributes)));
         } catch (Exception e) {
-            LOG.error("exception[{}] step[{}] details[{}]",
-                e.getClass().getName(),
-                "RowToPubsubMessageFn.processElement()",
-                e.toString()
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}]",
+                    e.getClass().getName(),
+                    "RowToPubsubMessageFn.processElement()",
+                    e.toString());
         }
     }
 }

--- a/core/src/main/java/org/streamprocessor/core/transforms/RowToPubsubMessageFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/RowToPubsubMessageFn.java
@@ -41,10 +41,12 @@ public class RowToPubsubMessageFn extends DoFn<Row, KV<String, PubsubMessage>> {
 
     static final long serialVersionUID = 234L;
 
-    public RowToPubsubMessageFn() {}
+    public RowToPubsubMessageFn() {
+    }
 
     @Setup
-    public void setup() throws Exception {}
+    public void setup() throws Exception {
+    }
 
     @ProcessElement
     public void processElement(@Element Row row, OutputReceiver<KV<String, PubsubMessage>> out)
@@ -73,21 +75,24 @@ public class RowToPubsubMessageFn extends DoFn<Row, KV<String, PubsubMessage>> {
                 eventUuid = UUID.randomUUID().toString();
             }
 
-            Map<String, String> attributes =
-                    new HashMap<String, String>() {
-                        static final long serialVersionUID = 2342534L;
+            Map<String, String> attributes = new HashMap<String, String>() {
+                static final long serialVersionUID = 2342534L;
 
-                        {
-                            put("timestamp", java.time.Instant.now().toString());
-                            put("event_timestamp", String.valueOf(eventTimestamp.getMillis()));
-                            put("event_uuid", eventUuid);
-                            put("entity", entity);
-                        }
-                    };
+                {
+                    put("timestamp", java.time.Instant.now().toString());
+                    put("event_timestamp", String.valueOf(eventTimestamp.getMillis()));
+                    put("event_uuid", eventUuid);
+                    put("entity", entity);
+                }
+            };
 
             out.output(KV.of(entity, new PubsubMessage(str.getBytes("UTF-8"), attributes)));
         } catch (Exception e) {
-            LOG.error("RowToPubsubMessage: " + e.getMessage());
+            LOG.error("exception[{}] step[{}] details[{}]",
+                e.getClass().getName(),
+                "RowToPubsubMessageFn.processElement()",
+                e.toString()
+            );
         }
     }
 }

--- a/core/src/main/java/org/streamprocessor/core/transforms/SalesforceFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SalesforceFn.java
@@ -60,6 +60,7 @@ public class SalesforceFn extends DoFn<PubsubMessage, PubsubMessage> {
                 attributes.put("entity", received.getAttribute("topic"));
             }
 
+            String entity = attributes.get("entity");
             JSONObject payloadObject;
 
             try {
@@ -103,14 +104,28 @@ public class SalesforceFn extends DoFn<PubsubMessage, PubsubMessage> {
                 out.output(
                         new PubsubMessage(payloadObject.toString().getBytes("UTF-8"), attributes));
             } catch (IllegalArgumentException e) {
-                LOG.error("IllegalArgumentException: ", e);
+                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
+                    e.getClass().getName(),
+                    "DynamodbFn.processElement()",
+                    e.toString(),
+                    entity
+                );
             } catch (org.json.JSONException e) {
-                LOG.error("org.json.JSONException: ", e);
+                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
+                    e.getClass().getName(),
+                    "DynamodbFn.processElement()",
+                    e.toString(),
+                    entity
+                );
             } catch (Exception e) {
-                LOG.error("Exception: ", e);
+                throw e;
             }
         } catch (Exception e) {
-            LOG.error(e.getMessage());
+            LOG.error("exception[{}] step[{}] details[{}]",
+                e.getClass().getName(),
+                "DynamodbFn.processElement()",
+                e.toString()
+            );
         }
     }
 }

--- a/core/src/main/java/org/streamprocessor/core/transforms/SalesforceFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SalesforceFn.java
@@ -117,8 +117,6 @@ public class SalesforceFn extends DoFn<PubsubMessage, PubsubMessage> {
                         "DynamodbFn.processElement()",
                         e.toString(),
                         entity);
-            } catch (Exception e) {
-                throw e;
             }
         } catch (Exception e) {
             LOG.error(

--- a/core/src/main/java/org/streamprocessor/core/transforms/SalesforceFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SalesforceFn.java
@@ -104,28 +104,28 @@ public class SalesforceFn extends DoFn<PubsubMessage, PubsubMessage> {
                 out.output(
                         new PubsubMessage(payloadObject.toString().getBytes("UTF-8"), attributes));
             } catch (IllegalArgumentException e) {
-                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
-                    e.getClass().getName(),
-                    "DynamodbFn.processElement()",
-                    e.toString(),
-                    entity
-                );
+                LOG.error(
+                        "exception[{}] step[{}] details[{}] entity[{}]",
+                        e.getClass().getName(),
+                        "DynamodbFn.processElement()",
+                        e.toString(),
+                        entity);
             } catch (org.json.JSONException e) {
-                LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
-                    e.getClass().getName(),
-                    "DynamodbFn.processElement()",
-                    e.toString(),
-                    entity
-                );
+                LOG.error(
+                        "exception[{}] step[{}] details[{}] entity[{}]",
+                        e.getClass().getName(),
+                        "DynamodbFn.processElement()",
+                        e.toString(),
+                        entity);
             } catch (Exception e) {
                 throw e;
             }
         } catch (Exception e) {
-            LOG.error("exception[{}] step[{}] details[{}]",
-                e.getClass().getName(),
-                "DynamodbFn.processElement()",
-                e.toString()
-            );
+            LOG.error(
+                    "exception[{}] step[{}] details[{}]",
+                    e.getClass().getName(),
+                    "DynamodbFn.processElement()",
+                    e.toString());
         }
     }
 }

--- a/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
@@ -146,13 +146,6 @@ public class SerializeMessageToRowFn extends DoFn<PubsubMessage, Row> {
                     "SerializeMessageToRowFn.processElement()",
                     e.toString(),
                     entity
-                    // TODO: Add labels to error for consumption by log monitoring tool
-                    // Map.of(
-                    //     "entity", entity,
-                    //     "dataset", datasetId,
-                    //     "error_code", e.getClass().getName(),
-                    //     "error_step", "SerializeMessageToRowFn.processElement()"
-                    // )
                     );
             // TODO:
             // instead, pass the following to deadletter: original_payload, status, error_message

--- a/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
@@ -132,8 +132,27 @@ public class SerializeMessageToRowFn extends DoFn<PubsubMessage, Row> {
 
             Row row = BqUtils.toBeamRow(schema, tr);
             out.get(successTag).output(row);
+        } catch (NoSchemaException e) {
+            LOG.warn("exception[{}] step[{}] details[{}] entity[{}]",
+                "NoSchemaException",
+                "SerializeMessageToRowFn.processElement()",    
+                e.toString(),
+                entity
+            );
         } catch (Exception e) {
-            LOG.error(entity + ": " + e.toString());
+            LOG.error("exception[{}] step[{}] details[{}] entity[{}]",
+                e.getClass().getName(),
+                "SerializeMessageToRowFn.processElement()",
+                e.toString(),
+                entity
+                // TODO: Add labels to error for consumption by log monitoring tool
+                // Map.of(
+                //     "entity", entity,
+                //     "dataset", datasetId,
+                //     "error_code", e.getClass().getName(),
+                //     "error_step", "SerializeMessageToRowFn.processElement()"
+                // )
+            );
             // TODO:
             // instead, pass the following to deadletter: original_payload, status, error_message
             // can't put in unmodifiable map

--- a/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/SerializeMessageToRowFn.java
@@ -145,8 +145,7 @@ public class SerializeMessageToRowFn extends DoFn<PubsubMessage, Row> {
                     e.getClass().getName(),
                     "SerializeMessageToRowFn.processElement()",
                     e.toString(),
-                    entity
-                    );
+                    entity);
             // TODO:
             // instead, pass the following to deadletter: original_payload, status, error_message
             // can't put in unmodifiable map

--- a/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
@@ -16,6 +16,7 @@
 
 package org.streamprocessor.core.utils;
 
+import com.google.api.gax.rpc.PermissionDeniedException;
 import com.google.cloud.datacatalog.v1beta1.DataCatalogClient;
 import com.google.cloud.datacatalog.v1beta1.Entry;
 import com.google.cloud.datacatalog.v1beta1.LookupEntryRequest;
@@ -99,6 +100,13 @@ public final class CacheLoaderUtils implements Serializable {
             Schema schema =
                     Schema.builder().addFields(taggedFieldList).build().withOptions(schemaOptions);
             return schema;
+        } catch (PermissionDeniedException e) {
+            LOG.warn("exception[{}] step[{}] details[{}]",
+                "PermissionDeniedException",
+                "CacheLoaderUtils.getSchema()",
+                e.toString()
+            );
+            return Schema.builder().build();
         } catch (Exception e) {
             LOG.error("exception[{}] step[{}] details[{}]",
                 e.getClass().getName(),

--- a/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
@@ -124,11 +124,11 @@ public final class CacheLoaderUtils implements Serializable {
                 try {
                     return getSchema(sqlResource);
                 } catch (Exception e) {
-                    LOG.error("exception[{}] step[{}] details[{}]",
-                        e.getClass().getName(),
-                        "CacheLoaderUtils.schemaCacheLoader()",
-                        e.toString()
-                    );
+                    LOG.error(
+                            "exception[{}] step[{}] details[{}]",
+                            e.getClass().getName(),
+                            "CacheLoaderUtils.schemaCacheLoader()",
+                            e.toString());
                     return null;
                 }
             }

--- a/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/CacheLoaderUtils.java
@@ -100,7 +100,11 @@ public final class CacheLoaderUtils implements Serializable {
                     Schema.builder().addFields(taggedFieldList).build().withOptions(schemaOptions);
             return schema;
         } catch (Exception e) {
-            LOG.error(e.toString());
+            LOG.error("exception[{}] step[{}] details[{}]",
+                e.getClass().getName(),
+                "CacheLoaderUtils.getSchema()",
+                e.toString()
+            );
             return Schema.builder().build();
         }
     }
@@ -112,7 +116,11 @@ public final class CacheLoaderUtils implements Serializable {
                 try {
                     return getSchema(sqlResource);
                 } catch (Exception e) {
-                    LOG.error(e.toString());
+                    LOG.error("exception[{}] step[{}] details[{}]",
+                        e.getClass().getName(),
+                        "CacheLoaderUtils.schemaCacheLoader()",
+                        e.toString()
+                    );
                     return null;
                 }
             }

--- a/pipelines/dynamodb/src/main/java/org/streamprocessor/pipelines/Dynamodb.java
+++ b/pipelines/dynamodb/src/main/java/org/streamprocessor/pipelines/Dynamodb.java
@@ -164,7 +164,11 @@ public class Dynamodb {
         // options.setNumberOfWorkerHarnessThreads(10);
         options.setStreaming(true);
         options.setEnableStreamingEngine(true);
-        LOG.info("NumberOfWorkerHarnessThreads: " + options.getNumberOfWorkerHarnessThreads()); // TODO: Logging msg not informative and labelled enough
+        LOG.info(
+                "NumberOfWorkerHarnessThreads: "
+                        + options.getNumberOfWorkerHarnessThreads()); // TODO: Logging msg not
+        // informative and labelled
+        // enough
 
         // validateOptions(options);  // to-do create a validation function...
 
@@ -274,10 +278,11 @@ public class Dynamodb {
                                                                         " The error was "
                                                                                 + x.getError())
                                                                 .toString();
-                                                LOG.error("exception[FailedInsertsException] step[{}] details[{}]",
+                                                LOG.error(
+                                                        "exception[FailedInsertsException] step[{}]"
+                                                                + " details[{}]",
                                                         "Dynamodb.main()",
-                                                        message
-                                                );
+                                                        message);
                                                 return "";
                                             }));
         }

--- a/pipelines/dynamodb/src/main/java/org/streamprocessor/pipelines/Dynamodb.java
+++ b/pipelines/dynamodb/src/main/java/org/streamprocessor/pipelines/Dynamodb.java
@@ -164,7 +164,7 @@ public class Dynamodb {
         // options.setNumberOfWorkerHarnessThreads(10);
         options.setStreaming(true);
         options.setEnableStreamingEngine(true);
-        LOG.info("NumberOfWorkerHarnessThreads: " + options.getNumberOfWorkerHarnessThreads());
+        LOG.info("NumberOfWorkerHarnessThreads: " + options.getNumberOfWorkerHarnessThreads()); // TODO: Logging msg not informative and labelled enough
 
         // validateOptions(options);  // to-do create a validation function...
 
@@ -274,7 +274,11 @@ public class Dynamodb {
                                                                         " The error was "
                                                                                 + x.getError())
                                                                 .toString();
-                                                LOG.error(message);
+                                                LOG.error("exception[FailedInsertsException] step[{}] details[{}]",
+                                                        e.getClass().getName(),
+                                                        "Dynamodb.main()",
+                                                        message
+                                                );
                                                 return "";
                                             }));
         }

--- a/pipelines/dynamodb/src/main/java/org/streamprocessor/pipelines/Dynamodb.java
+++ b/pipelines/dynamodb/src/main/java/org/streamprocessor/pipelines/Dynamodb.java
@@ -275,7 +275,6 @@ public class Dynamodb {
                                                                                 + x.getError())
                                                                 .toString();
                                                 LOG.error("exception[FailedInsertsException] step[{}] details[{}]",
-                                                        e.getClass().getName(),
                                                         "Dynamodb.main()",
                                                         message
                                                 );

--- a/pipelines/salesforce/src/main/java/org/streamprocessor/pipelines/Salesforce.java
+++ b/pipelines/salesforce/src/main/java/org/streamprocessor/pipelines/Salesforce.java
@@ -276,7 +276,6 @@ public class Salesforce {
                                                                         " The error was "
                                                                                 + x.getError())
                                                                 .toString();
-                                                LOG.error(message);
                                                 LOG.error(
                                                         "exception[FailedInsertsException] step[{}]"
                                                                 + " details[{}]",

--- a/pipelines/salesforce/src/main/java/org/streamprocessor/pipelines/Salesforce.java
+++ b/pipelines/salesforce/src/main/java/org/streamprocessor/pipelines/Salesforce.java
@@ -277,6 +277,10 @@ public class Salesforce {
                                                                                 + x.getError())
                                                                 .toString();
                                                 LOG.error(message);
+                                                LOG.error("exception[FailedInsertsException] step[{}] details[{}]",
+                                                        "Salesforce.main()",
+                                                        message
+                                                );
                                                 return "";
                                             }));
         }

--- a/pipelines/salesforce/src/main/java/org/streamprocessor/pipelines/Salesforce.java
+++ b/pipelines/salesforce/src/main/java/org/streamprocessor/pipelines/Salesforce.java
@@ -277,10 +277,11 @@ public class Salesforce {
                                                                                 + x.getError())
                                                                 .toString();
                                                 LOG.error(message);
-                                                LOG.error("exception[FailedInsertsException] step[{}] details[{}]",
+                                                LOG.error(
+                                                        "exception[FailedInsertsException] step[{}]"
+                                                                + " details[{}]",
                                                         "Salesforce.main()",
-                                                        message
-                                                );
+                                                        message);
                                                 return "";
                                             }));
         }


### PR DESCRIPTION
This feature aims to sharpen the error logging to be more informative and usable when querying from Logs explorer. We add keywords and a corresponding bracket to be able to filter what you need in logs explorer, like: jsonPayload.message=~"exception\[MissingSchemaException\]" to get all fails where we tossed a missing schema exception. 

We are yet to discover how to add some of this metadata as labels to the log payload instead of in the message string. But solving the ability to filter is the first and most important issue to deal with. 