### PR TITLE
DATA-3036: support more timestamp formats

### DIFF
--- a/core/src/main/java/org/streamprocessor/core/utils/BqUtils.java
+++ b/core/src/main/java/org/streamprocessor/core/utils/BqUtils.java
@@ -131,6 +131,7 @@ public class BqUtils {
     private static final DateTimeFormatter Z_TIMESTAMP_PARSER;
     private static final DateTimeFormatter Z_TIMESTAMP_PARSER_WITHOUT_T;
     private static final DateTimeFormatter OFFS_TIMESTAMP_PARSER;
+    private static final DateTimeFormatter OFFS_TIMESTAMP_PARSER_WITHOUT_T;
     private static final DateTimeFormatter DATETIME_PARSER;
 
     static {
@@ -184,6 +185,17 @@ public class BqUtils {
         OFFS_TIMESTAMP_PARSER =
                 new DateTimeFormatterBuilder()
                         .append(dateTimePartT)
+                        .appendOptional(
+                                new DateTimeFormatterBuilder()
+                                        .appendLiteral('.')
+                                        .appendFractionOfSecond(2, 7)
+                                        .toParser())
+                        .appendTimeZoneOffset(null, true, 2, 2)
+                        .toFormatter()
+                        .withZoneUTC();
+        OFFS_TIMESTAMP_PARSER_WITHOUT_T =
+                new DateTimeFormatterBuilder()
+                        .append(dateTimePart)
                         .appendOptional(
                                 new DateTimeFormatterBuilder()
                                         .appendLiteral('.')
@@ -277,6 +289,10 @@ public class BqUtils {
                                             .toDateTime(DateTimeZone.UTC);
                                 } else if (str.contains("T")) {
                                     return DATETIME_PARSER
+                                            .parseDateTime(str)
+                                            .toDateTime(DateTimeZone.UTC);
+                                } else if (str.contains("+")) {
+                                    return OFFS_TIMESTAMP_PARSER_WITHOUT_T
                                             .parseDateTime(str)
                                             .toDateTime(DateTimeZone.UTC);
                                 } else {
@@ -518,7 +534,9 @@ public class BqUtils {
                             + field.getType()
                             + "`"
                             + " with value "
-                            + bqValue);
+                            + bqValue
+                            + "\nOriginal exception:"
+                            + e.toString());
         }
     }
 

--- a/core/src/test/java/org/streamprocessor/core/utils/BqUtilsTest.java
+++ b/core/src/test/java/org/streamprocessor/core/utils/BqUtilsTest.java
@@ -54,6 +54,7 @@ public class BqUtilsTest {
                     .addNullableField("timestamp_variant3", Schema.FieldType.DATETIME)
                     .addNullableField("timestamp_variant4", Schema.FieldType.DATETIME)
                     .addNullableField("timestamp_variant5", Schema.FieldType.DATETIME)
+                    .addNullableField("timestamp_variant6", Schema.FieldType.DATETIME)
                     .addNullableField("datetime", Schema.FieldType.logicalType(SqlTypes.DATETIME))
                     .addNullableField(
                             "datetime0ms", Schema.FieldType.logicalType(SqlTypes.DATETIME))
@@ -100,6 +101,9 @@ public class BqUtilsTest {
                             ISODateTimeFormat.dateTimeNoMillis()
                                     .withZoneUTC()
                                     .parseDateTime("2019-08-19T16:52:07Z"),
+                            ISODateTimeFormat.dateHourMinuteSecondFraction()
+                                    .withZoneUTC()
+                                    .parseDateTime("2023-03-06T15:29:39.766"),
                             LocalDateTime.parse("2020-11-02T12:34:56.789876"),
                             LocalDateTime.parse("2020-11-02T12:34:56"),
                             LocalDateTime.parse("2020-11-02T12:34:00.789876"),
@@ -133,6 +137,7 @@ public class BqUtilsTest {
                                                     .getMillis()
                                             / 1000.0D))
                     .put("timestamp_variant5", "2019-08-19 16:52:07Z")
+                    .put("timestamp_variant6", "2023-03-06 15:29:39.766632+00:00")
                     .put("datetime", "2020-11-02T12:34:56.789876")
                     .put("datetime0ms", "2020-11-02T12:34:56")
                     .put("datetime0s_ns", "2020-11-02T12:34:00.789876")
@@ -183,7 +188,7 @@ public class BqUtilsTest {
             Row.withSchema(FLAT_TYPE)
                     .addValues(
                             null, null, null, null, null, null, null, null, null, null, null, null,
-                            null, null, null, null, null, null, null, null, null, null, null)
+                            null, null, null, null, null, null, null, null, null, null, null, null)
                     .build();
 
     private static final TableRow BQ_NULL_FLAT_ROW =
@@ -196,6 +201,7 @@ public class BqUtilsTest {
                     .set("timestamp_variant3", null)
                     .set("timestamp_variant4", null)
                     .set("timestamp_variant5", null)
+                    .set("timestamp_variant6", null)
                     .set("datetime", null)
                     .set("datetime0ms", null)
                     .set("datetime0s_ns", null)


### PR DESCRIPTION
Adds supports for timestamps on the format:

```
2023-03-10 08:34:56.023734+00:00
```