### PR TITLE
DATA-3230: Allow bucket data ingestion pattern for data contracts

### DIFF
--- a/core/src/main/java/org/streamprocessor/core/helpers/CloudStorageImportHelper.java
+++ b/core/src/main/java/org/streamprocessor/core/helpers/CloudStorageImportHelper.java
@@ -1,0 +1,51 @@
+package org.streamprocessor.core.helpers;
+
+import java.util.HashMap;
+import org.json.JSONObject;
+import org.streamprocessor.core.transforms.MetadataFields;
+import org.streamprocessor.core.utils.CustomExceptionsUtils;
+
+public class CloudStorageImportHelper {
+
+    public static final String METADATA = "_metadata";
+    public static final String TIMESTAMP = "timestamp";
+    public static final String UUID = "uuid";
+
+    public static JSONObject enrichPubsubMessage(
+            JSONObject customEventStreamObject, HashMap<String, String> attributes)
+            throws Exception {
+
+        JSONObject metadata = customEventStreamObject.getJSONObject(METADATA);
+        metadata.put(MetadataFields.OPERATION, MetadataFields.Operation.INSERT.getValue());
+
+        metadata.put(
+                MetadataFields.EXTRACT_METHOD,
+                MetadataFields.ExtractMethod.CLOUD_STORAGE_IMPORT.getValue());
+
+        // add event_time to payload root for streaming analytics use cases
+        if (customEventStreamObject.isNull(MetadataFields.EVENT_TIMESTAMP)) {
+            if (attributes.containsKey(TIMESTAMP)) {
+                customEventStreamObject.put(
+                        MetadataFields.EVENT_TIMESTAMP, attributes.get(TIMESTAMP));
+            } else {
+                throw new CustomExceptionsUtils.MissingMetadataException(
+                        String.format("No `%s` found in message", MetadataFields.EVENT_TIMESTAMP));
+            }
+        }
+
+        // Add meta-data from custom events as attributes
+        if (!customEventStreamObject.isNull(MetadataFields.EVENT_ID)) {
+            metadata.put(
+                    MetadataFields.EVENT_ID,
+                    customEventStreamObject.getString(MetadataFields.EVENT_ID));
+        } else if (attributes.containsKey(UUID)) {
+            metadata.put(MetadataFields.EVENT_ID, attributes.get(UUID));
+        } else {
+            throw new CustomExceptionsUtils.MissingMetadataException(
+                    String.format(
+                            "No `%s` or `%s` found in message.", MetadataFields.EVENT_ID, UUID));
+        }
+        customEventStreamObject.put(METADATA, metadata);
+        return customEventStreamObject;
+    }
+}

--- a/core/src/main/java/org/streamprocessor/core/transforms/MetadataFields.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/MetadataFields.java
@@ -13,6 +13,7 @@ public class MetadataFields {
     @AllArgsConstructor
     @Getter
     public enum ExtractMethod {
+        CLOUD_STORAGE_IMPORT("cloud_storage_import"),
         CUSTOM_EVENT("custom_event"),
         CDC("cdc");
         private final String value;

--- a/core/src/main/java/org/streamprocessor/core/transforms/TransformMessageFn.java
+++ b/core/src/main/java/org/streamprocessor/core/transforms/TransformMessageFn.java
@@ -18,6 +18,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.streamprocessor.core.caches.DataContractsCache;
+import org.streamprocessor.core.helpers.CloudStorageImportHelper;
 import org.streamprocessor.core.helpers.CustomEventHelper;
 import org.streamprocessor.core.helpers.DynamodbHelper;
 import org.streamprocessor.core.helpers.SalesforceHelper;
@@ -134,6 +135,10 @@ public class TransformMessageFn
                 case "pi":
                     transformedPayload =
                             CustomEventHelper.enrichPubsubMessage(streamObject, attributes);
+                    break;
+                case "cloud_storage_import":
+                    transformedPayload =
+                            CloudStorageImportHelper.enrichPubsubMessage(streamObject, attributes);
                     break;
                 default:
                     throw new CustomExceptionsUtils.UnknownPorviderException(


### PR DESCRIPTION
Add another helper for Cloud Storage Imports. Metadata is extracted the same way as custom events